### PR TITLE
타이틀에서 사용하는 배경을 계속해서 보존하도록 한다

### DIFF
--- a/Assets/Images.meta
+++ b/Assets/Images.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: 21ff4cc29a6e03041a3645204eef5efc
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Assets/Prefabs/Canvas/UI_Ending.prefab
+++ b/Assets/Prefabs/Canvas/UI_Ending.prefab
@@ -217,7 +217,7 @@ GameObject:
   - component: {fileID: 2775253770401530868}
   - component: {fileID: 1434055441}
   m_Layer: 5
-  m_Name: EndingCanvas
+  m_Name: UI_Ending
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -318,9 +318,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ca0ad3744a49c444f8a26c779edff5a3, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  TitleSeceneIndex: 0
-  MainGameSeceneIndex: 0
-  EndingSeceneIndex: 0
   SumDayText: {fileID: 2775253771682140463}
   EndDayText: {fileID: 2775253771665167061}
 --- !u!1 &2775253770496031141

--- a/Assets/Scenes/MainGame/Ending.unity
+++ b/Assets/Scenes/MainGame/Ending.unity
@@ -98,7 +98,7 @@ LightmapSettings:
     m_TrainingDataDestination: TrainingData
     m_LightProbeSampleCountMultiplier: 4
   m_LightingDataAsset: {fileID: 0}
-  m_UseShadowmask: 0
+  m_UseShadowmask: 1
 --- !u!196 &4
 NavMeshSettings:
   serializedVersion: 2
@@ -206,6 +206,16 @@ PrefabInstance:
         type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2775253769933868758, guid: 617d83de707ea1f4a908d8ec21e61793,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
+      value: LoadScene
+      objectReference: {fileID: 0}
+    - target: {fileID: 2775253769933868758, guid: 617d83de707ea1f4a908d8ec21e61793,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Mode
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 2775253770401530869, guid: 617d83de707ea1f4a908d8ec21e61793,
         type: 3}
@@ -321,6 +331,21 @@ PrefabInstance:
         type: 3}
       propertyPath: m_IsActive
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2775253770515757033, guid: 617d83de707ea1f4a908d8ec21e61793,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
+      value: LoadScene
+      objectReference: {fileID: 0}
+    - target: {fileID: 2775253770515757033, guid: 617d83de707ea1f4a908d8ec21e61793,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Mode
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 2775253770515757033, guid: 617d83de707ea1f4a908d8ec21e61793,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_IntArgument
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 2775253771163351681, guid: 617d83de707ea1f4a908d8ec21e61793,
         type: 3}

--- a/Assets/Scenes/MainGame/Ending.unity
+++ b/Assets/Scenes/MainGame/Ending.unity
@@ -98,7 +98,7 @@ LightmapSettings:
     m_TrainingDataDestination: TrainingData
     m_LightProbeSampleCountMultiplier: 4
   m_LightingDataAsset: {fileID: 0}
-  m_UseShadowmask: 1
+  m_UseShadowmask: 0
 --- !u!196 &4
 NavMeshSettings:
   serializedVersion: 2
@@ -121,75 +121,6 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
---- !u!1001 &522447575
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 9100194444520918709, guid: 64b6abaa0d482ac42927b090b86d7e2d,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 9100194444520918709, guid: 64b6abaa0d482ac42927b090b86d7e2d,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 9100194444520918709, guid: 64b6abaa0d482ac42927b090b86d7e2d,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 9100194444520918709, guid: 64b6abaa0d482ac42927b090b86d7e2d,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 9100194444520918709, guid: 64b6abaa0d482ac42927b090b86d7e2d,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 9100194444520918709, guid: 64b6abaa0d482ac42927b090b86d7e2d,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 9100194444520918709, guid: 64b6abaa0d482ac42927b090b86d7e2d,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 9100194444520918709, guid: 64b6abaa0d482ac42927b090b86d7e2d,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 2
-      objectReference: {fileID: 0}
-    - target: {fileID: 9100194444520918709, guid: 64b6abaa0d482ac42927b090b86d7e2d,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 9100194444520918709, guid: 64b6abaa0d482ac42927b090b86d7e2d,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 9100194444520918709, guid: 64b6abaa0d482ac42927b090b86d7e2d,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 9100194444520918714, guid: 64b6abaa0d482ac42927b090b86d7e2d,
-        type: 3}
-      propertyPath: m_Name
-      value: Thema-nuclearWar
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 64b6abaa0d482ac42927b090b86d7e2d, type: 3}
 --- !u!1 &1387159717
 GameObject:
   m_ObjectHideFlags: 0
@@ -254,7 +185,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 3
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &1434055439
 PrefabInstance:

--- a/Assets/Scenes/MainGame/Main.unity
+++ b/Assets/Scenes/MainGame/Main.unity
@@ -457,80 +457,6 @@ MonoBehaviour:
   m_RequiresDepthTexture: 0
   m_RequiresColorTexture: 0
   m_Version: 2
---- !u!1001 &311916977
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 7348036569173657550, guid: b97f1c63a52cbcf41af03f63aca30e6f,
-        type: 3}
-      propertyPath: m_Name
-      value: Thema-iceAge
-      objectReference: {fileID: 0}
-    - target: {fileID: 7348036569173657550, guid: b97f1c63a52cbcf41af03f63aca30e6f,
-        type: 3}
-      propertyPath: m_IsActive
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7348036569173657551, guid: b97f1c63a52cbcf41af03f63aca30e6f,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7348036569173657551, guid: b97f1c63a52cbcf41af03f63aca30e6f,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7348036569173657551, guid: b97f1c63a52cbcf41af03f63aca30e6f,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7348036569173657551, guid: b97f1c63a52cbcf41af03f63aca30e6f,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7348036569173657551, guid: b97f1c63a52cbcf41af03f63aca30e6f,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7348036569173657551, guid: b97f1c63a52cbcf41af03f63aca30e6f,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7348036569173657551, guid: b97f1c63a52cbcf41af03f63aca30e6f,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 7348036569173657551, guid: b97f1c63a52cbcf41af03f63aca30e6f,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 13
-      objectReference: {fileID: 0}
-    - target: {fileID: 7348036569173657551, guid: b97f1c63a52cbcf41af03f63aca30e6f,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7348036569173657551, guid: b97f1c63a52cbcf41af03f63aca30e6f,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7348036569173657551, guid: b97f1c63a52cbcf41af03f63aca30e6f,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: b97f1c63a52cbcf41af03f63aca30e6f, type: 3}
 --- !u!1 &314796657
 GameObject:
   m_ObjectHideFlags: 0
@@ -1023,7 +949,7 @@ RectTransform:
   m_Children:
   - {fileID: 719962824}
   m_Father: {fileID: 1732917975}
-  m_RootOrder: 8
+  m_RootOrder: 7
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -1109,95 +1035,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 719962823}
   m_CullTransparentMesh: 0
---- !u!1001 &759485242
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 9100194443042235275, guid: 64b6abaa0d482ac42927b090b86d7e2d,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -2.85
-      objectReference: {fileID: 0}
-    - target: {fileID: 9100194444074752488, guid: 64b6abaa0d482ac42927b090b86d7e2d,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -0.27
-      objectReference: {fileID: 0}
-    - target: {fileID: 9100194444520918709, guid: 64b6abaa0d482ac42927b090b86d7e2d,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 9100194444520918709, guid: 64b6abaa0d482ac42927b090b86d7e2d,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 9100194444520918709, guid: 64b6abaa0d482ac42927b090b86d7e2d,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 9100194444520918709, guid: 64b6abaa0d482ac42927b090b86d7e2d,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 9100194444520918709, guid: 64b6abaa0d482ac42927b090b86d7e2d,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 9100194444520918709, guid: 64b6abaa0d482ac42927b090b86d7e2d,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 9100194444520918709, guid: 64b6abaa0d482ac42927b090b86d7e2d,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 9100194444520918709, guid: 64b6abaa0d482ac42927b090b86d7e2d,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 14
-      objectReference: {fileID: 0}
-    - target: {fileID: 9100194444520918709, guid: 64b6abaa0d482ac42927b090b86d7e2d,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 9100194444520918709, guid: 64b6abaa0d482ac42927b090b86d7e2d,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 9100194444520918709, guid: 64b6abaa0d482ac42927b090b86d7e2d,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 9100194444520918714, guid: 64b6abaa0d482ac42927b090b86d7e2d,
-        type: 3}
-      propertyPath: m_Name
-      value: Thema-nuclearWar
-      objectReference: {fileID: 0}
-    - target: {fileID: 9100194444520918714, guid: 64b6abaa0d482ac42927b090b86d7e2d,
-        type: 3}
-      propertyPath: m_IsActive
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 9100194444588963510, guid: 64b6abaa0d482ac42927b090b86d7e2d,
-        type: 3}
-      propertyPath: m_IsActive
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 64b6abaa0d482ac42927b090b86d7e2d, type: 3}
 --- !u!224 &781110848 stripped
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 445515386065862716, guid: 3e9168a92e603b0468e0250b631bc6fc,
@@ -2057,85 +1894,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1272890890}
   m_CullTransparentMesh: 0
---- !u!1001 &1301079925
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 4094495448320558341, guid: d56c3a62e850d2947846523b391aec05,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4094495448320558341, guid: d56c3a62e850d2947846523b391aec05,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4094495448320558341, guid: d56c3a62e850d2947846523b391aec05,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4094495448320558341, guid: d56c3a62e850d2947846523b391aec05,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4094495448320558341, guid: d56c3a62e850d2947846523b391aec05,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4094495448320558341, guid: d56c3a62e850d2947846523b391aec05,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4094495448320558341, guid: d56c3a62e850d2947846523b391aec05,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4094495448320558341, guid: d56c3a62e850d2947846523b391aec05,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 15
-      objectReference: {fileID: 0}
-    - target: {fileID: 4094495448320558341, guid: d56c3a62e850d2947846523b391aec05,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4094495448320558341, guid: d56c3a62e850d2947846523b391aec05,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4094495448320558341, guid: d56c3a62e850d2947846523b391aec05,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4094495448320558342, guid: d56c3a62e850d2947846523b391aec05,
-        type: 3}
-      propertyPath: m_Name
-      value: Thema-posionous
-      objectReference: {fileID: 0}
-    - target: {fileID: 4094495448320558342, guid: d56c3a62e850d2947846523b391aec05,
-        type: 3}
-      propertyPath: m_IsActive
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4094495448815064667, guid: d56c3a62e850d2947846523b391aec05,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -4.6
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: d56c3a62e850d2947846523b391aec05, type: 3}
 --- !u!1 &1453388208
 GameObject:
   m_ObjectHideFlags: 0
@@ -2208,12 +1966,6 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 7
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &1461678364 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 9100194444520918714, guid: 64b6abaa0d482ac42927b090b86d7e2d,
-    type: 3}
-  m_PrefabInstance: {fileID: 759485242}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1491883352
 GameObject:
   m_ObjectHideFlags: 0
@@ -2695,12 +2447,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1663710783}
   m_CullTransparentMesh: 0
---- !u!1 &1681592126 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 4094495448320558342, guid: d56c3a62e850d2947846523b391aec05,
-    type: 3}
-  m_PrefabInstance: {fileID: 1301079925}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1732917971
 GameObject:
   m_ObjectHideFlags: 0
@@ -2798,8 +2544,8 @@ RectTransform:
   - {fileID: 1613046589}
   - {fileID: 335365040}
   - {fileID: 781110848}
-  - {fileID: 781691510}
   - {fileID: 651721604}
+  - {fileID: 781691510}
   m_Father: {fileID: 0}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -2882,12 +2628,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1767225433}
   m_CullTransparentMesh: 0
---- !u!1 &1799506758 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 7348036569173657550, guid: b97f1c63a52cbcf41af03f63aca30e6f,
-    type: 3}
-  m_PrefabInstance: {fileID: 311916977}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1830433122
 GameObject:
   m_ObjectHideFlags: 0
@@ -2992,10 +2732,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   mEndingIndex: 2
-  Themas:
-  - {fileID: 1799506758}
-  - {fileID: 1461678364}
-  - {fileID: 1681592126}
 --- !u!4 &1863035267
 Transform:
   m_ObjectHideFlags: 0
@@ -3008,7 +2744,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 16
+  m_RootOrder: 13
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1888353340
 GameObject:

--- a/Assets/Scenes/MainGame/Title.unity
+++ b/Assets/Scenes/MainGame/Title.unity
@@ -126,7 +126,7 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    m_TransformParent: {fileID: 682604508}
+    m_TransformParent: {fileID: 1193437035}
     m_Modifications:
     - target: {fileID: 7348036569173657550, guid: b97f1c63a52cbcf41af03f63aca30e6f,
         type: 3}
@@ -201,69 +201,12 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 265438242}
   m_PrefabAsset: {fileID: 0}
---- !u!1 &265438244 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 7348036569173657550, guid: b97f1c63a52cbcf41af03f63aca30e6f,
-    type: 3}
-  m_PrefabInstance: {fileID: 265438242}
-  m_PrefabAsset: {fileID: 0}
---- !u!1 &682604506
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 682604508}
-  - component: {fileID: 682604507}
-  m_Layer: 0
-  m_Name: TitleAction
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!114 &682604507
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 682604506}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a3004fc243bf7074692d92dd21f368c0, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  MainGameScenceIndex: 1
-  ThemaObjets:
-  - {fileID: 1424234470}
-  - {fileID: 1104767330}
-  - {fileID: 265438244}
---- !u!4 &682604508
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 682604506}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children:
-  - {fileID: 1424234469}
-  - {fileID: 1104767329}
-  - {fileID: 265438243}
-  m_Father: {fileID: 0}
-  m_RootOrder: 3
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &1104767328
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    m_TransformParent: {fileID: 682604508}
+    m_TransformParent: {fileID: 1193437035}
     m_Modifications:
     - target: {fileID: 4094495448320558341, guid: d56c3a62e850d2947846523b391aec05,
         type: 3}
@@ -338,12 +281,39 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1104767328}
   m_PrefabAsset: {fileID: 0}
---- !u!1 &1104767330 stripped
+--- !u!1 &1193437034
 GameObject:
-  m_CorrespondingSourceObject: {fileID: 4094495448320558342, guid: d56c3a62e850d2947846523b391aec05,
-    type: 3}
-  m_PrefabInstance: {fileID: 1104767328}
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1193437035}
+  m_Layer: 0
+  m_Name: ThemaParent
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1193437035
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1193437034}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 1424234469}
+  - {fileID: 1104767329}
+  - {fileID: 265438243}
+  m_Father: {fileID: 0}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &1299437291
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -499,7 +469,7 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    m_TransformParent: {fileID: 682604508}
+    m_TransformParent: {fileID: 1193437035}
     m_Modifications:
     - target: {fileID: 9100194444520918709, guid: 64b6abaa0d482ac42927b090b86d7e2d,
         type: 3}
@@ -571,12 +541,6 @@ PrefabInstance:
 --- !u!4 &1424234469 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 9100194444520918709, guid: 64b6abaa0d482ac42927b090b86d7e2d,
-    type: 3}
-  m_PrefabInstance: {fileID: 1424234468}
-  m_PrefabAsset: {fileID: 0}
---- !u!1 &1424234470 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 9100194444520918714, guid: 64b6abaa0d482ac42927b090b86d7e2d,
     type: 3}
   m_PrefabInstance: {fileID: 1424234468}
   m_PrefabAsset: {fileID: 0}
@@ -902,6 +866,7 @@ GameObject:
   - component: {fileID: 1964120638}
   - component: {fileID: 1964120637}
   - component: {fileID: 1964120636}
+  - component: {fileID: 1964120639}
   m_Layer: 5
   m_Name: Button
   m_TagString: Untagged
@@ -941,7 +906,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Navigation:
-    m_Mode: 3
+    m_Mode: -1
     m_SelectOnUp: {fileID: 0}
     m_SelectOnDown: {fileID: 0}
     m_SelectOnLeft: {fileID: 0}
@@ -971,7 +936,7 @@ MonoBehaviour:
   m_OnClick:
     m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 682604507}
+      - m_Target: {fileID: 1964120639}
         m_MethodName: MainGameLoad
         m_Mode: 1
         m_Arguments:
@@ -1019,6 +984,20 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1964120634}
   m_CullTransparentMesh: 0
+--- !u!114 &1964120639
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1964120634}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a3004fc243bf7074692d92dd21f368c0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  MainGameIndex: 1
+  ThemaParent: {fileID: 1193437035}
 --- !u!1 &8797928081604153193 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 377491110146082470, guid: 17f741253953d164a88740d9051fe38c,

--- a/Assets/Scenes/MainGame/Title.unity
+++ b/Assets/Scenes/MainGame/Title.unity
@@ -121,6 +121,229 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
+--- !u!1001 &265438242
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 682604508}
+    m_Modifications:
+    - target: {fileID: 7348036569173657550, guid: b97f1c63a52cbcf41af03f63aca30e6f,
+        type: 3}
+      propertyPath: m_Name
+      value: Thema-iceAge
+      objectReference: {fileID: 0}
+    - target: {fileID: 7348036569173657550, guid: b97f1c63a52cbcf41af03f63aca30e6f,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7348036569173657551, guid: b97f1c63a52cbcf41af03f63aca30e6f,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7348036569173657551, guid: b97f1c63a52cbcf41af03f63aca30e6f,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7348036569173657551, guid: b97f1c63a52cbcf41af03f63aca30e6f,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7348036569173657551, guid: b97f1c63a52cbcf41af03f63aca30e6f,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7348036569173657551, guid: b97f1c63a52cbcf41af03f63aca30e6f,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7348036569173657551, guid: b97f1c63a52cbcf41af03f63aca30e6f,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7348036569173657551, guid: b97f1c63a52cbcf41af03f63aca30e6f,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7348036569173657551, guid: b97f1c63a52cbcf41af03f63aca30e6f,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 7348036569173657551, guid: b97f1c63a52cbcf41af03f63aca30e6f,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7348036569173657551, guid: b97f1c63a52cbcf41af03f63aca30e6f,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7348036569173657551, guid: b97f1c63a52cbcf41af03f63aca30e6f,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: b97f1c63a52cbcf41af03f63aca30e6f, type: 3}
+--- !u!4 &265438243 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7348036569173657551, guid: b97f1c63a52cbcf41af03f63aca30e6f,
+    type: 3}
+  m_PrefabInstance: {fileID: 265438242}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &265438244 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 7348036569173657550, guid: b97f1c63a52cbcf41af03f63aca30e6f,
+    type: 3}
+  m_PrefabInstance: {fileID: 265438242}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &682604506
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 682604508}
+  - component: {fileID: 682604507}
+  m_Layer: 0
+  m_Name: TitleAction
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &682604507
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 682604506}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a3004fc243bf7074692d92dd21f368c0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  MainGameScenceIndex: 1
+  ThemaObjets:
+  - {fileID: 1424234470}
+  - {fileID: 1104767330}
+  - {fileID: 265438244}
+--- !u!4 &682604508
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 682604506}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 1424234469}
+  - {fileID: 1104767329}
+  - {fileID: 265438243}
+  m_Father: {fileID: 0}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &1104767328
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 682604508}
+    m_Modifications:
+    - target: {fileID: 4094495448320558341, guid: d56c3a62e850d2947846523b391aec05,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4094495448320558341, guid: d56c3a62e850d2947846523b391aec05,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4094495448320558341, guid: d56c3a62e850d2947846523b391aec05,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4094495448320558341, guid: d56c3a62e850d2947846523b391aec05,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4094495448320558341, guid: d56c3a62e850d2947846523b391aec05,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4094495448320558341, guid: d56c3a62e850d2947846523b391aec05,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4094495448320558341, guid: d56c3a62e850d2947846523b391aec05,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4094495448320558341, guid: d56c3a62e850d2947846523b391aec05,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4094495448320558341, guid: d56c3a62e850d2947846523b391aec05,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4094495448320558341, guid: d56c3a62e850d2947846523b391aec05,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4094495448320558341, guid: d56c3a62e850d2947846523b391aec05,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4094495448320558342, guid: d56c3a62e850d2947846523b391aec05,
+        type: 3}
+      propertyPath: m_Name
+      value: Thema-poisonous
+      objectReference: {fileID: 0}
+    - target: {fileID: 4094495448320558342, guid: d56c3a62e850d2947846523b391aec05,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d56c3a62e850d2947846523b391aec05, type: 3}
+--- !u!4 &1104767329 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4094495448320558341, guid: d56c3a62e850d2947846523b391aec05,
+    type: 3}
+  m_PrefabInstance: {fileID: 1104767328}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1104767330 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 4094495448320558342, guid: d56c3a62e850d2947846523b391aec05,
+    type: 3}
+  m_PrefabInstance: {fileID: 1104767328}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1299437291
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -186,7 +409,7 @@ PrefabInstance:
     - target: {fileID: 5505365441550998199, guid: e511ec6f235159745867dbc784e0055a,
         type: 3}
       propertyPath: m_RootOrder
-      value: 2
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 5505365441550998199, guid: e511ec6f235159745867dbc784e0055a,
         type: 3}
@@ -276,7 +499,7 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    m_TransformParent: {fileID: 0}
+    m_TransformParent: {fileID: 682604508}
     m_Modifications:
     - target: {fileID: 9100194444520918709, guid: 64b6abaa0d482ac42927b090b86d7e2d,
         type: 3}
@@ -296,17 +519,17 @@ PrefabInstance:
     - target: {fileID: 9100194444520918709, guid: 64b6abaa0d482ac42927b090b86d7e2d,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 9100194444520918709, guid: 64b6abaa0d482ac42927b090b86d7e2d,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 9100194444520918709, guid: 64b6abaa0d482ac42927b090b86d7e2d,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 9100194444520918709, guid: 64b6abaa0d482ac42927b090b86d7e2d,
         type: 3}
@@ -316,7 +539,7 @@ PrefabInstance:
     - target: {fileID: 9100194444520918709, guid: 64b6abaa0d482ac42927b090b86d7e2d,
         type: 3}
       propertyPath: m_RootOrder
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 9100194444520918709, guid: 64b6abaa0d482ac42927b090b86d7e2d,
         type: 3}
@@ -338,8 +561,25 @@ PrefabInstance:
       propertyPath: m_Name
       value: Thema-nuclearWar
       objectReference: {fileID: 0}
+    - target: {fileID: 9100194444520918714, guid: 64b6abaa0d482ac42927b090b86d7e2d,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 64b6abaa0d482ac42927b090b86d7e2d, type: 3}
+--- !u!4 &1424234469 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 9100194444520918709, guid: 64b6abaa0d482ac42927b090b86d7e2d,
+    type: 3}
+  m_PrefabInstance: {fileID: 1424234468}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1424234470 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 9100194444520918714, guid: 64b6abaa0d482ac42927b090b86d7e2d,
+    type: 3}
+  m_PrefabInstance: {fileID: 1424234468}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1489073619
 GameObject:
   m_ObjectHideFlags: 0
@@ -519,7 +759,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 3
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1778432251
 GameObject:
@@ -662,7 +902,6 @@ GameObject:
   - component: {fileID: 1964120638}
   - component: {fileID: 1964120637}
   - component: {fileID: 1964120636}
-  - component: {fileID: 1964120639}
   m_Layer: 5
   m_Name: Button
   m_TagString: Untagged
@@ -732,7 +971,7 @@ MonoBehaviour:
   m_OnClick:
     m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 1964120639}
+      - m_Target: {fileID: 682604507}
         m_MethodName: MainGameLoad
         m_Mode: 1
         m_Arguments:
@@ -780,19 +1019,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1964120634}
   m_CullTransparentMesh: 0
---- !u!114 &1964120639
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1964120634}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a3004fc243bf7074692d92dd21f368c0, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  MainGameScenceIndex: 1
 --- !u!1 &8797928081604153193 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 377491110146082470, guid: 17f741253953d164a88740d9051fe38c,

--- a/Assets/Scenes/MainGame/Title.unity
+++ b/Assets/Scenes/MainGame/Title.unity
@@ -138,6 +138,11 @@ PrefabInstance:
       propertyPath: m_IsActive
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 7348036569173657550, guid: b97f1c63a52cbcf41af03f63aca30e6f,
+        type: 3}
+      propertyPath: m_TagString
+      value: Thema
+      objectReference: {fileID: 0}
     - target: {fileID: 7348036569173657551, guid: b97f1c63a52cbcf41af03f63aca30e6f,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -272,6 +277,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_IsActive
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4094495448320558342, guid: d56c3a62e850d2947846523b391aec05,
+        type: 3}
+      propertyPath: m_TagString
+      value: Thema
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: d56c3a62e850d2947846523b391aec05, type: 3}
@@ -535,6 +545,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_IsActive
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9100194444520918714, guid: 64b6abaa0d482ac42927b090b86d7e2d,
+        type: 3}
+      propertyPath: m_TagString
+      value: Thema
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 64b6abaa0d482ac42927b090b86d7e2d, type: 3}

--- a/Assets/Scenes/MainGame/Title.unity
+++ b/Assets/Scenes/MainGame/Title.unity
@@ -206,6 +206,24 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 265438242}
   m_PrefabAsset: {fileID: 0}
+--- !u!95 &603811234 stripped
+Animator:
+  m_CorrespondingSourceObject: {fileID: 413835518, guid: e511ec6f235159745867dbc784e0055a,
+    type: 3}
+  m_PrefabInstance: {fileID: 1299437291}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &603811235 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 5505365440680223856, guid: e511ec6f235159745867dbc784e0055a,
+    type: 3}
+  m_PrefabInstance: {fileID: 1299437291}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &1104767328
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -674,6 +692,18 @@ MonoBehaviour:
   m_RequiresDepthTexture: 0
   m_RequiresColorTexture: 0
   m_Version: 2
+--- !u!114 &1572473023 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 5505365440496721523, guid: e511ec6f235159745867dbc784e0055a,
+    type: 3}
+  m_PrefabInstance: {fileID: 1299437291}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &1754721337
 GameObject:
   m_ObjectHideFlags: 0
@@ -1013,6 +1043,9 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   MainGameIndex: 1
   ThemaParent: {fileID: 1193437035}
+  TitleImage: {fileID: 1572473023}
+  Tap2PlayImage: {fileID: 603811235}
+  Tap2PlayAnim: {fileID: 603811234}
 --- !u!1 &8797928081604153193 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 377491110146082470, guid: 17f741253953d164a88740d9051fe38c,

--- a/Assets/Scripts/GameFlow/Ending/EndingAction.cs
+++ b/Assets/Scripts/GameFlow/Ending/EndingAction.cs
@@ -7,33 +7,32 @@ using InGame.UI.Week;
 
 public class EndingAction : MonoBehaviour
 {
-    [SerializeField]
-    private int TitleSeceneIndex;
-    [SerializeField]
-    private int MainGameSeceneIndex;
-    [SerializeField]
-    private int EndingSeceneIndex;
-    [SerializeField]
-    private Text SumDayText;
-    [SerializeField]
-    private Text EndDayText;
+    [SerializeField] private Text SumDayText;
+    [SerializeField] private Text EndDayText;
 
-    public void LoadTitle()
+    private Transform mTitleAction;
+
+    public void LoadScene(int sceneIndex)
     {
-        Destroy((FindObjectOfType(typeof(TitleAction)) as TitleAction).gameObject);
+        Destroy(mTitleAction.gameObject);
 
-        SceneManager.LoadScene(TitleSeceneIndex);
+        SceneManager.LoadScene(sceneIndex);
     }
-    public void LoadMainGame()
-    {
-        Destroy((FindObjectOfType(typeof(TitleAction)) as TitleAction).gameObject);
 
-        SceneManager.LoadScene(MainGameSeceneIndex);
-    }
     private void Start()
     {
-        DaySaver day = FindObjectOfType(typeof(DaySaver)) as DaySaver;
+        DaySaver day = 
+             FindObjectOfType(typeof(DaySaver)) as DaySaver;
 
+        mTitleAction =
+            (FindObjectOfType(typeof(TitleAction)) as TitleAction).transform;
+
+        for (int i = 0; i< mTitleAction.childCount; ++i) 
+        {
+            if (mTitleAction.GetChild(i).gameObject.activeSelf) {
+                mTitleAction.GetChild(i).parent = transform;
+            }
+        }
         SumDayText.text = day.SumDay();
         EndDayText.text = day.WeekDay();
 

--- a/Assets/Scripts/GameFlow/Ending/EndingAction.cs
+++ b/Assets/Scripts/GameFlow/Ending/EndingAction.cs
@@ -20,10 +20,14 @@ public class EndingAction : MonoBehaviour
 
     public void LoadTitle()
     {
+        Destroy((FindObjectOfType(typeof(TitleAction)) as TitleAction).gameObject);
+
         SceneManager.LoadScene(TitleSeceneIndex);
     }
     public void LoadMainGame()
     {
+        Destroy((FindObjectOfType(typeof(TitleAction)) as TitleAction).gameObject);
+
         SceneManager.LoadScene(MainGameSeceneIndex);
     }
     private void Start()

--- a/Assets/Scripts/GameFlow/Ending/EndingAction.cs
+++ b/Assets/Scripts/GameFlow/Ending/EndingAction.cs
@@ -10,12 +10,8 @@ public class EndingAction : MonoBehaviour
     [SerializeField] private Text SumDayText;
     [SerializeField] private Text EndDayText;
 
-    private Transform mTitleAction;
-
     public void LoadScene(int sceneIndex)
     {
-        Destroy(mTitleAction.gameObject);
-
         SceneManager.LoadScene(sceneIndex);
     }
 
@@ -24,15 +20,8 @@ public class EndingAction : MonoBehaviour
         DaySaver day = 
              FindObjectOfType(typeof(DaySaver)) as DaySaver;
 
-        mTitleAction =
-            (FindObjectOfType(typeof(TitleAction)) as TitleAction).transform;
+        GameObject.FindGameObjectWithTag("Thema").transform.parent = transform;
 
-        for (int i = 0; i< mTitleAction.childCount; ++i) 
-        {
-            if (mTitleAction.GetChild(i).gameObject.activeSelf) {
-                mTitleAction.GetChild(i).parent = transform;
-            }
-        }
         SumDayText.text = day.SumDay();
         EndDayText.text = day.WeekDay();
 

--- a/Assets/Scripts/GameFlow/GameOver/GameOverAction.cs
+++ b/Assets/Scripts/GameFlow/GameOver/GameOverAction.cs
@@ -15,14 +15,6 @@ public class GameOverAction : MonoBehaviour
 
     private ResourceTable mResourceTable;
 
-    [SerializeField]
-    private GameObject[] Themas;
-
-    private void Awake()
-    {
-        Themas[Random.Range(0, Themas.Length)].SetActive(true);
-    }
-
     private void Start()
     {
         GameEvent.Instance.SubscribeBubbleEvent(() => mSurvivalDay++);

--- a/Assets/Scripts/GameFlow/Title/TitleAction.cs
+++ b/Assets/Scripts/GameFlow/Title/TitleAction.cs
@@ -7,5 +7,17 @@ public class TitleAction : MonoBehaviour
 {
     [SerializeField]
     private int MainGameScenceIndex;
-    public void MainGameLoad() => SceneManager.LoadScene(MainGameScenceIndex);
+
+    [Space()][SerializeField]
+    private GameObject[] ThemaObjets;
+    
+    public void MainGameLoad() {
+        SceneManager.LoadScene(MainGameScenceIndex);
+    }
+
+    private void Awake()
+    {
+        ThemaObjets[Random.Range(0, ThemaObjets.Length)].SetActive(true);
+        DontDestroyOnLoad(gameObject);
+    }
 }

--- a/Assets/Scripts/GameFlow/Title/TitleAction.cs
+++ b/Assets/Scripts/GameFlow/Title/TitleAction.cs
@@ -11,14 +11,19 @@ public class TitleAction : MonoBehaviour
     [SerializeField]
     private Transform ThemaParent;
 
-    private AsyncOperation mAsnycSceneLoad;
+    [SerializeField]
+    private UnityEngine.UI.Image TitleImage;
+    [SerializeField]
+    private UnityEngine.UI.Image Tap2PlayImage;
+    
+    [SerializeField]
+    private Animator Tap2PlayAnim;
+
+    private AsyncOperation mAsyncSceneLoad;
 
     public void MainGameLoad()
     {
-        if (mAsnycSceneLoad?.progress >= 0.9f) 
-        {
-            mAsnycSceneLoad.allowSceneActivation = true;
-        }
+        StartCoroutine(ESceneLoad());
     }
 
     private void Awake()
@@ -30,17 +35,28 @@ public class TitleAction : MonoBehaviour
         DontDestroyOnLoad(thema.gameObject);
     }
 
-    private void Start() {
-        StartCoroutine(ESceneLoad());
-    }
-
     private IEnumerator ESceneLoad()
     {
-        yield return new WaitForSeconds(0.1f);
+        var async = 
+            SceneManager.LoadSceneAsync(MainGameIndex, LoadSceneMode.Single);
+            
+        async.allowSceneActivation = false;
 
-        mAsnycSceneLoad =
-           SceneManager.LoadSceneAsync(MainGameIndex, LoadSceneMode.Single);
+        while (async.progress < 0.9f)
+        {
+            yield return null;
+        }
+        Tap2PlayAnim.enabled = false;
 
-        mAsnycSceneLoad.allowSceneActivation = false;
+        while (TitleImage.color.a > 0)
+        {
+            yield return null;
+
+            float deltaTime = Time.deltaTime;
+
+               TitleImage.color -= Color.black * deltaTime * 0.3f;
+            Tap2PlayImage.color -= Color.black * deltaTime * 0.3f;
+        }
+        async.allowSceneActivation = true;
     }
 }

--- a/Assets/Scripts/GameFlow/Title/TitleAction.cs
+++ b/Assets/Scripts/GameFlow/Title/TitleAction.cs
@@ -1,23 +1,46 @@
 ﻿using System.Collections;
-using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.SceneManagement;
 
 public class TitleAction : MonoBehaviour
 {
     [SerializeField]
-    private int MainGameScenceIndex;
+    private int MainGameIndex;
 
-    [Space()][SerializeField]
-    private GameObject[] ThemaObjets;
-    
-    public void MainGameLoad() {
-        SceneManager.LoadScene(MainGameScenceIndex);
+    [Space()]
+    [SerializeField]
+    private Transform ThemaParent;
+
+    private AsyncOperation mAsnycSceneLoad;
+
+    public void MainGameLoad()
+    {
+        if (mAsnycSceneLoad?.progress >= 0.9f) 
+        {
+            mAsnycSceneLoad.allowSceneActivation = true;
+        }
     }
 
     private void Awake()
+    {        
+        Transform thema = ThemaParent.GetChild(Random.Range(0, ThemaParent.childCount));
+
+                          thema.parent = null;
+                          thema.gameObject.SetActive(true);
+        DontDestroyOnLoad(thema.gameObject);
+    }
+
+    private void Start() {
+        StartCoroutine(ESceneLoad());
+    }
+
+    private IEnumerator ESceneLoad()
     {
-        ThemaObjets[Random.Range(0, ThemaObjets.Length)].SetActive(true);
-        DontDestroyOnLoad(gameObject);
+        yield return new WaitForSeconds(0.1f);
+
+        mAsnycSceneLoad =
+           SceneManager.LoadSceneAsync(MainGameIndex, LoadSceneMode.Single);
+
+        mAsnycSceneLoad.allowSceneActivation = false;
     }
 }

--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -3,7 +3,8 @@
 --- !u!78 &1
 TagManager:
   serializedVersion: 2
-  tags: []
+  tags:
+  - Thema
   layers:
   - Default
   - TransparentFX


### PR DESCRIPTION
## 배경 오브젝트 보존
- 타이틀에서 사용되는 배경 오브젝트들은 무작위로 정해지고, 정해진 오브젝트는 `DontDestroyOnLoad`를 통해 보존한다.
- 보존된 배경 오브젝트는 `Ending`씬에서 다른 씬으로 이동할 때, 파괴된다.
## Main씬 전환
- 타이틀에서 `Main`씬으로 전환하기 이전에 Fade-out을 실행하도록 한다. 
- 타이틀에서 Main씬으로 전환하는 과정은 : 
1. 비동기로 Main씬을 불러온다.
2. 씬을 불러왔다면, Fade-out을 실행한다. Fade-out이 끝났을때 Main씬으로 전환한다.

- Main씬을 불러오는 순간은 화면을 클릭했을 때이다.