### PR TITLE
시위 버블이 인게임에 나오질 않는 버그 수정

### DIFF
--- a/Assets/Scripts/Bubble/Special/SpecialBubbleSystem.cs
+++ b/Assets/Scripts/Bubble/Special/SpecialBubbleSystem.cs
@@ -53,13 +53,16 @@ namespace InGame.Bubble
             Policy policy = ConvertSpecialBubbleToPolicy(type);
             if (!PolicySystem.Instance.IsExistAccumulatePolicy(policy))
                 return false;
-
+            
             GameObject[] bubbleObjects = GameObject.FindGameObjectsWithTag("Bubble") as GameObject[];
             GameObject poolObject = InstantiateSpecialBubble(type);
             poolObject.GetComponent<SpecialBubbleButton>().SpecialBubbleUP();
 
 
             PolicySystem.Instance.RemoveAccumulatePolicy(policy);
+
+            Event.SwitchID ConvertedSwitch = ConvertSpecialBubbleToSwitch(type);
+            GameEvent.Instance.switchCondition.SwitchOff(ConvertedSwitch);
 
             StartCoroutine(EUpdate(poolObject, bubbleObjects[Random.Range(0, bubbleObjects.Length)]));
             return true;
@@ -100,13 +103,29 @@ namespace InGame.Bubble
                 case SpecialBubbleType.REBELLION:
                     return Policy.PopulationDownSize;
                 case SpecialBubbleType.DEMONSTRATE:
-                    return Policy.ExtraWork;
+                    return Policy.FoodSaving;
                 case SpecialBubbleType.FALSE_RELIGION:
                     return Policy.MissionaryWork;
                 default:
                     return Policy.None;
             }
         }
+
+        public Event.SwitchID ConvertSpecialBubbleToSwitch(SpecialBubbleType specialBubbleType)
+        {
+            switch (specialBubbleType)
+            {
+                case SpecialBubbleType.REBELLION:
+                    return Event.SwitchID.NO7;
+                case SpecialBubbleType.DEMONSTRATE:
+                    return Event.SwitchID.NO6;
+                case SpecialBubbleType.FALSE_RELIGION:
+                    return Event.SwitchID.NO5;
+                default:
+                    return Event.SwitchID.None;
+            }
+        }
+
 
         public GameObject InstantiateSpecialBubble(SpecialBubbleType type)
         {

--- a/Assets/Scripts/Event/EventSystem/SwitchCondition.cs
+++ b/Assets/Scripts/Event/EventSystem/SwitchCondition.cs
@@ -42,6 +42,7 @@ namespace InGame.Event
         /// 야간 노동 (SWITCH)
         /// </summary>
         NO9,
+        None,
     }
 
     public class SwitchCondition : MonoBehaviour

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "com.unity.2d.animation": {
-      "version": "3.2.3",
+      "version": "3.2.5",
       "depth": 0,
       "source": "registry",
       "dependencies": {
@@ -35,12 +35,12 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.2d.psdimporter": {
-      "version": "2.1.4",
+      "version": "2.1.6",
       "depth": 0,
       "source": "registry",
       "dependencies": {
         "com.unity.2d.common": "2.0.2",
-        "com.unity.2d.animation": "3.2.2",
+        "com.unity.2d.animation": "3.2.5",
         "com.unity.2d.sprite": "1.0.0"
       },
       "url": "https://packages.unity.com"
@@ -52,13 +52,13 @@
       "dependencies": {}
     },
     "com.unity.2d.spriteshape": {
-      "version": "3.0.12",
+      "version": "3.0.14",
       "depth": 0,
       "source": "registry",
       "dependencies": {
         "com.unity.mathematics": "1.1.0",
         "com.unity.2d.common": "2.0.2",
-        "com.unity.2d.path": "2.0.5"
+        "com.unity.2d.path": "2.0.6"
       },
       "url": "https://packages.unity.com"
     },
@@ -92,7 +92,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.ide.vscode": {
-      "version": "1.2.1",
+      "version": "1.2.2",
       "depth": 0,
       "source": "registry",
       "dependencies": {},
@@ -134,7 +134,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.test-framework": {
-      "version": "1.1.16",
+      "version": "1.1.18",
       "depth": 0,
       "source": "registry",
       "dependencies": {


### PR DESCRIPTION
## 원인
- ``SpeicalBubble.cs`` 에서 SpecialBubble타입에 따라 그에 맞는 Policy를 변환시켜주는
함수 (ConvertSpecialBubbleToPolicy() : enum) 에서 잘못된 Policy를 리턴함
- Policy.FoodSaving -> Policy.ExtraWork 로 변경함으로써 해결한다.
