### PR TITLE
자원 및 게임 속 밸런스를 수정

### DIFF
--- a/Assets/Prefabs/Trains/PreserveRoom.prefab
+++ b/Assets/Prefabs/Trains/PreserveRoom.prefab
@@ -25,7 +25,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2031929052047559398}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 3.15, z: 0}
+  m_LocalPosition: {x: 0, y: 2, z: 0}
   m_LocalScale: {x: 0.5, y: 0.5, z: 1}
   m_Children: []
   m_Father: {fileID: 4062458376064474119}

--- a/Assets/Scripts/Bubble/Bubble.cs
+++ b/Assets/Scripts/Bubble/Bubble.cs
@@ -1,6 +1,6 @@
 ﻿using System.Collections;
-using System.Collections.Generic;
 using UnityEngine;
+using InGame.UI.Resource;
 
 namespace InGame.Bubble
 {
@@ -14,6 +14,10 @@ namespace InGame.Bubble
         public Vehicles GetVehicles() => vehicles;
 
         private BubbleSystem bubbleSystem;
+        private GameEvent gameEvent;
+
+        private Resource resource;
+
         public int lastBubbleTime = 0;
 
         private GameObject PoolObject;
@@ -76,6 +80,10 @@ namespace InGame.Bubble
         private void Start()
         {
             bubbleSystem = BubbleSystem.Instance;
+            gameEvent = GameEvent.Instance;
+
+            resource = gameEvent.GetResource;
+
             StartCoroutine(EInit());
         }
         IEnumerator EInit()
@@ -94,7 +102,7 @@ namespace InGame.Bubble
             });
             StartCoroutine(EUpdate());
 
-            GameEvent.Instance.SubscribeBubbleEvent(() => { BubbleTiming(); });
+            gameEvent.SubscribeBubbleEvent(() => { BubbleTiming(); });
             
         }
         IEnumerator EUpdate()
@@ -144,19 +152,18 @@ namespace InGame.Bubble
         /// <param name="vehicles">기차칸</param>
         protected void IncreaseResourceInBubble(Vehicles vehicles)
         {
+            const int _unitAmount = 1;
+
             switch (vehicles)
             {
                 case Vehicles.GUESTROOM:
-                    GameEvent.Instance.GetResource.ApplyPopulation(1);
-                    PopupSystem.Instance.SpawnPopup("+1", ResourceType.Population);
+                    resource.ApplyPopulation(_unitAmount);
                     break;
                 case Vehicles.CULTIVATION:
-                    GameEvent.Instance.GetResource.ApplyFood(1);
-                    PopupSystem.Instance.SpawnPopup("+1", ResourceType.Food);
+                    resource.ApplyFood(_unitAmount);
                     break;
                 case Vehicles.EDUCATION:
-                    GameEvent.Instance.GetResource.ApplyLeaderShip(1);
-                    PopupSystem.Instance.SpawnPopup("+1", ResourceType.LeaderShip);
+                    resource.ApplyLeaderShip(_unitAmount);
                     break;
                 default:
                     break;

--- a/Assets/Scripts/ChoiceSystem/Policy/PolicySystem.cs
+++ b/Assets/Scripts/ChoiceSystem/Policy/PolicySystem.cs
@@ -202,7 +202,7 @@ public class MedicalIndustry : IEnforcementable
     {
         int amount = (int)(GameEvent.Instance.InitResourceTable.foodTable.Max * 0.3f);
 
-        GameEvent.Instance.GetResource.ApplyPopulation(-amount);
+        GameEvent.Instance.GetResource.ApplyFood(-amount);
 
         GameEvent.Instance.GetResource.ApplyLeaderShip(5);
     }

--- a/Assets/Scripts/Event/Resource.cs
+++ b/Assets/Scripts/Event/Resource.cs
@@ -70,6 +70,9 @@ namespace InGame.UI.Resource
 
         public void ApplyLeaderShip(int amount = 1)
         {
+            if (_resourceTable.leaderShipTable.Now + amount >= _resourceTable.leaderShipTable.Max)
+                return;
+
             _resourceTable.leaderShipTable.Now =
             (uint)Mathf.Max(0, _resourceTable.leaderShipTable.Now + amount);
             PopupSystem.Instance.SpawnPopup((amount >= 0) ? "+" 

--- a/Assets/Scripts/Event/Resource.cs
+++ b/Assets/Scripts/Event/Resource.cs
@@ -70,7 +70,7 @@ namespace InGame.UI.Resource
 
         public void ApplyLeaderShip(int amount = 1)
         {
-            if (_resourceTable.leaderShipTable.Now + amount >= _resourceTable.leaderShipTable.Max)
+            if (_resourceTable.leaderShipTable.Now + amount > _resourceTable.leaderShipTable.Max)
                 return;
 
             _resourceTable.leaderShipTable.Now =

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -165,8 +165,7 @@
       "depth": 0,
       "source": "builtin",
       "dependencies": {
-        "com.unity.modules.ui": "1.0.0",
-        "com.unity.modules.imgui": "1.0.0"
+        "com.unity.modules.ui": "1.0.0"
       }
     },
     "com.unity.modules.ai": {


### PR DESCRIPTION
## 수정사항
- 증감 UI (자원 및에 ``+1`` 이나 ``-1``뜨는 UI) 가 중복으로 생성되는 문제를 수정
- 리더쉽 자원의 개수가 최대 개수보다 넘아갈 시 증가가 되지 않도록 수정
- 의료사업 정책 시행 시 식량 자원이 감소되도록 수정 (인구 대신 식량이 감소되도록..)
- 보존실 오브젝트의 버블 생성 위치를 조금 아래로 수정