### PR TITLE
빌드 시 팝업 위치가 어긋나는 버그 수정

### DIFF
--- a/Assets/Scenes/MainGame/Main.unity
+++ b/Assets/Scenes/MainGame/Main.unity
@@ -98,7 +98,7 @@ LightmapSettings:
     m_TrainingDataDestination: TrainingData
     m_LightProbeSampleCountMultiplier: 4
   m_LightingDataAsset: {fileID: 0}
-  m_UseShadowmask: 1
+  m_UseShadowmask: 0
 --- !u!196 &4
 NavMeshSettings:
   serializedVersion: 2
@@ -151,6 +151,41 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &68685597
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 68685598}
+  m_Layer: 5
+  m_Name: Popup Point
+  m_TagString: Untagged
+  m_Icon: {fileID: 7174288486110832750, guid: 0000000000000000d000000000000000, type: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &68685598
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 68685597}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 2068179430}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: -83.5}
+  m_SizeDelta: {x: 100, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &185123742
 GameObject:
   m_ObjectHideFlags: 0
@@ -1630,6 +1665,7 @@ RectTransform:
   m_Children:
   - {fileID: 1994335878}
   - {fileID: 1830433123}
+  - {fileID: 1989224216}
   m_Father: {fileID: 273603793}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -2775,6 +2811,41 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1830433122}
   m_CullTransparentMesh: 0
+--- !u!1 &1856246391
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1856246392}
+  m_Layer: 5
+  m_Name: Popup Point
+  m_TagString: Untagged
+  m_Icon: {fileID: 8418204508859773708, guid: 0000000000000000d000000000000000, type: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1856246392
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1856246391}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.9999013, y: 0.9999013, z: 0.9999013}
+  m_Children: []
+  m_Father: {fileID: 1899677679}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: -83.5}
+  m_SizeDelta: {x: 100, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &1863035265
 GameObject:
   m_ObjectHideFlags: 0
@@ -2926,6 +2997,7 @@ RectTransform:
   m_Children:
   - {fileID: 430854564}
   - {fileID: 1767225434}
+  - {fileID: 1856246392}
   m_Father: {fileID: 273603793}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -3016,6 +3088,41 @@ MonoBehaviour:
   falseReligionBubble:
     prefab: {fileID: 8927305851283489208, guid: f2be845c1f0366347a2bfd8fd2aa7b40,
       type: 3}
+--- !u!1 &1989224215
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1989224216}
+  m_Layer: 5
+  m_Name: Popup Point
+  m_TagString: Untagged
+  m_Icon: {fileID: 2488908585195742037, guid: 0000000000000000d000000000000000, type: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1989224216
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1989224215}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.99990135, y: 0.99990135, z: 0.99990135}
+  m_Children: []
+  m_Father: {fileID: 1151636400}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: -83.5}
+  m_SizeDelta: {x: 100, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &1994335877
 GameObject:
   m_ObjectHideFlags: 0
@@ -3214,6 +3321,7 @@ RectTransform:
   m_Children:
   - {fileID: 1493612933}
   - {fileID: 185123743}
+  - {fileID: 68685598}
   m_Father: {fileID: 273603793}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -3516,6 +3624,39 @@ PrefabInstance:
       propertyPath: m_Pivot.y
       value: 0.5
       objectReference: {fileID: 0}
+    - target: {fileID: 445515386065862717, guid: 3e9168a92e603b0468e0250b631bc6fc,
+        type: 3}
+      propertyPath: mPopupPrefabs.FoodPopup
+      value: 
+      objectReference: {fileID: 2097929084518056398, guid: 402b9b5ec5cfe4b479a3820f305cffcb,
+        type: 3}
+    - target: {fileID: 445515386065862717, guid: 3e9168a92e603b0468e0250b631bc6fc,
+        type: 3}
+      propertyPath: mPopupPrefabs.populationPopup
+      value: 
+      objectReference: {fileID: 2448937182827939096, guid: fe732904e12c28d41976005d751430bd,
+        type: 3}
+    - target: {fileID: 445515386065862717, guid: 3e9168a92e603b0468e0250b631bc6fc,
+        type: 3}
+      propertyPath: mPopupPrefabs.LeadershipPopup
+      value: 
+      objectReference: {fileID: 4718243390921474948, guid: 83dd129ee1dc26a4a845bb90611f6253,
+        type: 3}
+    - target: {fileID: 445515386065862717, guid: 3e9168a92e603b0468e0250b631bc6fc,
+        type: 3}
+      propertyPath: mPopupTransform.populationPopup
+      value: 
+      objectReference: {fileID: 68685598}
+    - target: {fileID: 445515386065862717, guid: 3e9168a92e603b0468e0250b631bc6fc,
+        type: 3}
+      propertyPath: mPopupTransform.FoodPopup
+      value: 
+      objectReference: {fileID: 1989224216}
+    - target: {fileID: 445515386065862717, guid: 3e9168a92e603b0468e0250b631bc6fc,
+        type: 3}
+      propertyPath: mPopupTransform.LeadershipPopup
+      value: 
+      objectReference: {fileID: 1856246392}
     - target: {fileID: 445515386065862723, guid: 3e9168a92e603b0468e0250b631bc6fc,
         type: 3}
       propertyPath: m_Name

--- a/Assets/Scripts/Event/GameEvent.cs
+++ b/Assets/Scripts/Event/GameEvent.cs
@@ -138,6 +138,7 @@ public class GameEvent : Singleton<GameEvent>
 
     public EventEffect eventEffect;
     public SwitchCondition switchCondition;
+    public PopupSystem popupSystem;
 
     public void SubscribeMonthEvent(Action action) => GetWeek.OnMonthEvent += action;
     public void DescribeMonthEvent(Action action) => GetWeek.OnMonthEvent -= action;

--- a/Assets/Scripts/Event/Resource.cs
+++ b/Assets/Scripts/Event/Resource.cs
@@ -56,7 +56,7 @@ namespace InGame.UI.Resource
         {
             _resourceTable.populationTable.Now =
             (uint)Mathf.Max(0, _resourceTable.populationTable.Now + amount);
-            PopupSystem.Instance.SpawnPopup((amount >= 0) ? "+"
+            evt.popupSystem.SpawnPopup((amount >= 0) ? "+"
                 + amount.ToString() : amount.ToString(), ResourceType.Population);
         }
 
@@ -64,7 +64,7 @@ namespace InGame.UI.Resource
         {
             _resourceTable.foodTable.Now =
             (uint)Mathf.Max(0, _resourceTable.foodTable.Now + amount);
-            PopupSystem.Instance.SpawnPopup((amount >= 0) ? "+"
+            evt.popupSystem.SpawnPopup((amount >= 0) ? "+"
                 + amount.ToString() : amount.ToString(), ResourceType.Food);
         }
 
@@ -75,7 +75,7 @@ namespace InGame.UI.Resource
 
             _resourceTable.leaderShipTable.Now =
             (uint)Mathf.Max(0, _resourceTable.leaderShipTable.Now + amount);
-            PopupSystem.Instance.SpawnPopup((amount >= 0) ? "+" 
+            evt.popupSystem.SpawnPopup((amount >= 0) ? "+" 
                 + amount.ToString() : amount.ToString(), ResourceType.LeaderShip);
         }
 
@@ -83,7 +83,7 @@ namespace InGame.UI.Resource
         {
             _resourceTable.populationTable.Max =
             (uint)Mathf.Max(0, _resourceTable.populationTable.Max + amount);
-            PopupSystem.Instance.SpawnPopup((amount >= 0) ? "+"
+            evt.popupSystem.SpawnPopup((amount >= 0) ? "+"
                 + amount.ToString() : amount.ToString(), ResourceType.Population);
         }
 
@@ -91,7 +91,7 @@ namespace InGame.UI.Resource
         {
             _resourceTable.foodTable.Max =
             (uint)Mathf.Max(0, _resourceTable.foodTable.Max + amount);
-            PopupSystem.Instance.SpawnPopup((amount >= 0) ? "+" 
+            evt.popupSystem.SpawnPopup((amount >= 0) ? "+" 
                 + amount.ToString() : amount.ToString(), ResourceType.Food);
         }
 
@@ -99,7 +99,7 @@ namespace InGame.UI.Resource
         {
             _resourceTable.leaderShipTable.Max =
             (uint)Mathf.Max(0, _resourceTable.leaderShipTable.Max + amount);
-            PopupSystem.Instance.SpawnPopup((amount >= 0) ? "+"
+            evt.popupSystem.SpawnPopup((amount >= 0) ? "+"
                 + amount.ToString() : amount.ToString(), ResourceType.LeaderShip);
         }
 

--- a/Assets/Scripts/Popup/Popup.cs
+++ b/Assets/Scripts/Popup/Popup.cs
@@ -16,8 +16,8 @@ public class Popup : MonoBehaviour
     {
         text = GetComponent<Text>();
         text.color = mColor;
-        startPos = transform.position;
-        endPos = new Vector3(startPos.x, startPos.y + 500, startPos.z);
+        //startPos = transform.localPosition;
+        //endPos = new Vector3(startPos.x, startPos.y + 500, startPos.z);
         StartCoroutine(Processing());
     }
 
@@ -27,8 +27,8 @@ public class Popup : MonoBehaviour
         {
             if (text.color.a <= 0.1f)
                 Destroy(this.transform.parent.gameObject);
-             
-            transform.localPosition = Vector2.MoveTowards(startPos, endPos, DeltaTime * 5);
+
+            //transform.localPosition = Vector2.MoveTowards(startPos, endPos, DeltaTime * 5);
             //float y = Mathf.Lerp(transform.position.y, startPos.y + 20, DeltaTime);
 
             //transform.position = new Vector3(startPos.x, y, startPos.z);

--- a/Assets/Scripts/Popup/PopupSystem.cs
+++ b/Assets/Scripts/Popup/PopupSystem.cs
@@ -2,17 +2,52 @@
 using System.Collections.Generic;
 using UnityEngine;
 
-public class PopupSystem : Singleton<PopupSystem>
+
+public class PopupPointBase<T>
 {
-    public Transform parent;
+    public T populationPopup;
+    public T FoodPopup;
+    public T LeadershipPopup;
+}
 
-    public GameObject populationPopup;
-    public GameObject FoodPopup;
-    public GameObject LeadershipPopup;
+[System.Serializable]
+public class PopupObjectPoint : PopupPointBase<GameObject> { }
 
+[System.Serializable]
+public class PopupTransformPoint : PopupPointBase<Transform> { }
+
+[System.Serializable]
+public class PopupPositionPoint : PopupPointBase<Vector2> { }
+
+
+
+public class PopupSystem : MonoBehaviour
+{
+    [UnityEngine.Serialization.FormerlySerializedAs("parent")]
+    [SerializeField] Transform mParent;
+
+    [SerializeField] PopupObjectPoint    mPopupPrefabs;
+    [SerializeField] PopupTransformPoint mPopupTransform;
+    public PopupPositionPoint mPopupPoint;
+
+    private bool PositionCaching()
+    {
+        if (mPopupTransform.populationPopup == null
+            && mPopupTransform.FoodPopup == null
+            && mPopupTransform.LeadershipPopup == null)
+            return false;
+
+        mPopupPoint.populationPopup = CameraScreen.Instance.WorldToScreenPointWithCameraSpace(mPopupTransform.populationPopup.position);
+        mPopupPoint.FoodPopup       = CameraScreen.Instance.WorldToScreenPointWithCameraSpace(mPopupTransform.FoodPopup.position);
+        mPopupPoint.LeadershipPopup = CameraScreen.Instance.WorldToScreenPointWithCameraSpace(mPopupTransform.LeadershipPopup.position);
+        return true;
+    }
 
     public GameObject SpawnPopup(string number, ResourceType resourceType)
     {
+        PositionCaching();
+
+
         GameObject obj = null;
         UnityEngine.UI.Text text;
         switch (resourceType)
@@ -20,17 +55,23 @@ public class PopupSystem : Singleton<PopupSystem>
             case ResourceType.None:
                 break;
             case ResourceType.Population:
-                obj = Instantiate(populationPopup, parent);
+                obj = Instantiate(mPopupPrefabs.populationPopup, mParent);
+                obj.transform.localPosition = mPopupPoint.populationPopup;
+
                 text = obj.GetComponentInChildren<UnityEngine.UI.Text>();
                 text.text = number;
                 return obj;
             case ResourceType.Food:
-                obj = Instantiate(FoodPopup, parent);
+                obj = Instantiate(mPopupPrefabs.FoodPopup, mParent);
+                obj.transform.localPosition = mPopupPoint.FoodPopup;
+
                 text = obj.GetComponentInChildren<UnityEngine.UI.Text>();
                 text.text = number;
                 return obj;
             case ResourceType.LeaderShip:
-                obj = Instantiate(LeadershipPopup, parent);
+                obj = Instantiate(mPopupPrefabs.LeadershipPopup, mParent);
+                obj.transform.localPosition = mPopupPoint.LeadershipPopup;
+
                 text = obj.GetComponentInChildren<UnityEngine.UI.Text>();
                 text.text = number;
                 return obj;


### PR DESCRIPTION
## 변경사항
- 팝업 이동 억제 및 ``PopupSystem.cs``의 구조를 재편성
- ``PopupSystem.cs``의 싱글톤 제거 ``GameEvent.cs``에 삽입
- Main씬에 각 팝업 위치를 알려주는 오브젝트 추가